### PR TITLE
Adding string value support in array column relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ class Company extends Model
         return $this->belongsToArrayColumn(
             User::class,
             'id',
-            'companies'
+            'companies',
+            true // optional, default is false (if true then it treats all values as string)
         );
     }
 }

--- a/src/HasExtendedRelationships.php
+++ b/src/HasExtendedRelationships.php
@@ -37,10 +37,10 @@ trait HasExtendedRelationships
         return new HasManyArrayColumn($instance->newQuery(), $this, $foreignKey, $localKey);
     }
 
-    public function belongsToArrayColumn(string $related, ?string $foreignKey, ?string $localKey): BelongsToArrayColumn
+    public function belongsToArrayColumn(string $related, ?string $foreignKey, ?string $localKey, $isString = false): BelongsToArrayColumn
     {
         $instance = new $related();
 
-        return new BelongsToArrayColumn($instance->newQuery(), $this, $foreignKey, $localKey, null);
+        return new BelongsToArrayColumn($instance->newQuery(), $this, $foreignKey, $localKey, null, $isString);
     }
 }

--- a/src/HasExtendedRelationships.php
+++ b/src/HasExtendedRelationships.php
@@ -4,57 +4,43 @@ namespace Mrpunyapal\LaravelExtendedRelationships;
 
 use Mrpunyapal\LaravelExtendedRelationships\Relations\BelongsToArrayColumn;
 use Mrpunyapal\LaravelExtendedRelationships\Relations\BelongsToManyKeys;
-use Mrpunyapal\LaravelExtendedRelationships\Relations\HasManyKeys;
 use Mrpunyapal\LaravelExtendedRelationships\Relations\HasManyArrayColumn;
+use Mrpunyapal\LaravelExtendedRelationships\Relations\HasManyKeys;
 
 trait HasExtendedRelationships
 {
     /**
-     * @param  string  $related
      * @param  string|null  $foreignKey
      * @param  string[]|null  $relations
-     * @return BelongsToManyKeys
      */
     public function belongsToManyKeys(string $related, string $foreignKey, array $relations): BelongsToManyKeys
     {
         $instance = new $related();
+
         return new BelongsToManyKeys($instance->newQuery(), $this, $foreignKey, $relations);
     }
 
     /**
-     * @param  string  $related
      * @param  string[]|null  $relations
-     * @param  string|null  $localKey
-     * @return HasManyKeys
      */
     public function hasManyKeys(string $related, ?array $relations = null, ?string $localKey = null): HasManyKeys
     {
         $instance = new $related();
+
         return new HasManyKeys($instance->newQuery(), $this, $relations, $localKey);
     }
-    
-      /**
-     * @param  string  $related
-     * @param  string|null  $foreignKey
-     * @param  string|null  $localKey
-     * @return HasManyArrayColumn
-     */
-    public function hasManyArrayColumn(string $related, ?string $foreignKey, ?string $localKey):HasManyArrayColumn
+
+    public function hasManyArrayColumn(string $related, ?string $foreignKey, ?string $localKey): HasManyArrayColumn
     {
         $instance = new $related();
+
         return new HasManyArrayColumn($instance->newQuery(), $this, $foreignKey, $localKey);
     }
 
-    /**
-     * @param  string  $related
-     * @param  string|null  $foreignKey
-     * @param  string|null  $localKey
-     * @return BelongsToArrayColumn
-     */
     public function belongsToArrayColumn(string $related, ?string $foreignKey, ?string $localKey): BelongsToArrayColumn
     {
         $instance = new $related();
+
         return new BelongsToArrayColumn($instance->newQuery(), $this, $foreignKey, $localKey, null);
     }
-
 }

--- a/src/Relations/BelongsToArrayColumn.php
+++ b/src/Relations/BelongsToArrayColumn.php
@@ -8,6 +8,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class BelongsToArrayColumn extends BelongsTo
 {
+    /**
+     * Indicates whether the value is a string.
+     *
+     * @var bool
+     */
     protected $isString;
 
     /**

--- a/src/Relations/BelongsToArrayColumn.php
+++ b/src/Relations/BelongsToArrayColumn.php
@@ -17,7 +17,7 @@ class BelongsToArrayColumn extends BelongsTo
             $query = $this->getBaseQuery();
 
             $query->whereJsonContains($this->ownerKey, $this->getParentKey())
-                ->orWhereJsonContains($this->ownerKey, $this->getParentKey() . '');
+                ->orWhereJsonContains($this->ownerKey, $this->getParentKey().'');
 
             $query->whereNotNull($this->ownerKey);
         }
@@ -26,7 +26,6 @@ class BelongsToArrayColumn extends BelongsTo
     /**
      * Set the constraints for an eager load of the relation.
      *
-     * @param  array  $models
      * @return void
      */
     public function addEagerConstraints(array $models)
@@ -35,7 +34,7 @@ class BelongsToArrayColumn extends BelongsTo
         $this->query->where(function ($q) use ($ids) {
             foreach ($ids as $id) {
                 $q->orWhereJsonContains($this->ownerKey, $id)
-                    ->orWhereJsonContains($this->ownerKey, $id . '');
+                    ->orWhereJsonContains($this->ownerKey, $id.'');
             }
         });
     }
@@ -43,7 +42,6 @@ class BelongsToArrayColumn extends BelongsTo
     /**
      * Match the eagerly loaded results to their many parents.
      *
-     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -55,8 +53,9 @@ class BelongsToArrayColumn extends BelongsTo
             $id = $model->getAttribute($this->foreignKey);
             $collection = collect();
             foreach ($results as $data) {
-                if (in_array($id, $data->{$owner}))
+                if (in_array($id, $data->{$owner})) {
                     $collection->push($data);
+                }
             }
             $model->setRelation($relation, $collection);
         }

--- a/src/Relations/BelongsToManyKeys.php
+++ b/src/Relations/BelongsToManyKeys.php
@@ -15,6 +15,7 @@ class BelongsToManyKeys extends Relation
      * @var string[]
      */
     protected $localKeys;
+
     /**
      * The local keys of the parent model.
      *
@@ -32,9 +33,6 @@ class BelongsToManyKeys extends Relation
     /**
      * Create a new has one or many relationship instance.
      *
-     * @param  Builder  $query
-     * @param  Model  $parent
-     * @param  string  $foreignKey
      * @param  array  $localKeys
      * @return void
      */
@@ -69,8 +67,6 @@ class BelongsToManyKeys extends Relation
     /**
      * Set the constraints for an eager load of the relation.
      * Note: Used to load relations of multiple models at once.
-     *
-     * @param  array  $models
      */
     public function addEagerConstraints(array $models)
     {
@@ -86,7 +82,6 @@ class BelongsToManyKeys extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
      * @param  string  $relation
      * @return array
      */
@@ -107,14 +102,15 @@ class BelongsToManyKeys extends Relation
             $desireRelations = json_decode('{}');
             foreach ($this->localKeys as $localKey) {
                 $key = $model->getAttribute($localKey);
-                if (isset($dictionary[$key]))
+                if (isset($dictionary[$key])) {
                     $desireRelations->{$this->relations[$localKey]} = $dictionary[$key];
+                }
             }
             $model->setRelation($relation, $desireRelations);
         }
+
         return $models;
     }
-
 
     public function buildDictionary(Collection $models)
     {
@@ -122,15 +118,14 @@ class BelongsToManyKeys extends Relation
         foreach ($models as $model) {
             $dictionary[$model->{$this->foreignKey}] = $model;
         }
+
         return $dictionary;
     }
-
 
     public function getParentKey($localKey)
     {
         return $this->parent->getAttribute($localKey);
     }
-
 
     /**
      * Get the results of the relationship.
@@ -139,14 +134,15 @@ class BelongsToManyKeys extends Relation
      */
     public function getResults()
     {
-        if (!static::$constraints) {
-            return $this->query->get();;
+        if (! static::$constraints) {
+            return $this->query->get();
         }
         $results = $this->query->get();
         $desireResults = json_decode('{}');
         foreach ($this->localKeys as $localKey) {
             $desireResults->{$this->relations[$localKey]} = $results->where($this->foreignKey, '=', $this->getParentKey($localKey))->first();
         }
-        return  $desireResults;
+
+        return $desireResults;
     }
 }

--- a/src/Relations/HasManyArrayColumn.php
+++ b/src/Relations/HasManyArrayColumn.php
@@ -2,8 +2,8 @@
 
 namespace Mrpunyapal\LaravelExtendedRelationships\Relations;
 
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class HasManyArrayColumn extends HasMany
 {
@@ -26,7 +26,6 @@ class HasManyArrayColumn extends HasMany
     /**
      * Set the constraints for an eager load of the relation.
      *
-     * @param  array  $models
      * @return void
      */
     public function addEagerConstraints(array $models)
@@ -37,7 +36,6 @@ class HasManyArrayColumn extends HasMany
     /**
      * Get the Keys for an eager load of the relation.
      *
-     * @param  array  $models
      * @param  string|null  $key
      * @return void
      */
@@ -47,14 +45,13 @@ class HasManyArrayColumn extends HasMany
         collect($models)->each(function ($value) use ($key, &$keys) {
             $keys = array_merge($keys, array_map('intval', ($value->getAttribute($key) ?? [])));
         });
+
         return array_unique($keys);
     }
 
     /**
      * Match the eagerly loaded results to their many parents.
      *
-     * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
      */
@@ -71,8 +68,9 @@ class HasManyArrayColumn extends HasMany
             $ids = $model->getAttribute($this->localKey);
             $collection = collect();
             foreach ($ids ?? [] as $id) {
-                if (isset($dictionary[$id]))
+                if (isset($dictionary[$id])) {
                     $collection = $collection->merge($this->getRelationValue($dictionary, $id, 'many'));
+                }
             }
             $model->setRelation($relation, $collection);
         }

--- a/src/Relations/HasManyKeys.php
+++ b/src/Relations/HasManyKeys.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 
 class HasManyKeys extends Relation
 {
-
     /**
      * The foreign keys of the parent model.
      *
@@ -34,10 +33,6 @@ class HasManyKeys extends Relation
     /**
      * Create a new has one or many relationship instance.
      *
-     * @param  Builder  $query
-     * @param  Model  $parent
-     * @param  array  $relations
-     * @param  string  $localKey
      * @return void
      */
     public function __construct(Builder $query, Model $parent, array $relations, string $localKey)
@@ -52,8 +47,6 @@ class HasManyKeys extends Relation
     /**
      * Set the base constraints on the relation query.
      * Note: Used to load relations of one model.
-     *
-     * @return void
      */
     public function addConstraints(): void
     {
@@ -74,8 +67,6 @@ class HasManyKeys extends Relation
     /**
      * Set the constraints for an eager load of the relation.
      * Note: Used to load relations of multiple models at once.
-     *
-     * @param  array  $models
      */
     public function addEagerConstraints(array $models): void
     {
@@ -90,7 +81,6 @@ class HasManyKeys extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -107,8 +97,6 @@ class HasManyKeys extends Relation
      * Match the eagerly loaded results to their parents.
      * Info: From HasMany class.
      *
-     * @param  array  $models
-     * @param  Collection  $results
      * @param  string  $relation
      * @return array
      */
@@ -126,6 +114,7 @@ class HasManyKeys extends Relation
             }
             $model->setRelation($relation, $desireRelations);
         }
+
         return $models;
     }
 
@@ -134,7 +123,6 @@ class HasManyKeys extends Relation
      * Note: Custom code.
      *
      * @param  Collection  $results
-     * @return array
      */
     protected function buildDictionary(Collection $models): array
     {
@@ -145,6 +133,7 @@ class HasManyKeys extends Relation
                 $dictionary[$foreignKey][$model->{$foreignKey}] = $model;
             }
         }
+
         return $dictionary;
     }
 
@@ -166,7 +155,7 @@ class HasManyKeys extends Relation
      */
     public function getResults()
     {
-        if (!static::$constraints) {
+        if (! static::$constraints) {
             return $this->get();
         }
         $results = $this->get();
@@ -175,6 +164,7 @@ class HasManyKeys extends Relation
             $desireResults->{$this->relations[$foreignKey]} = $results->where($foreignKey, '=', $this->getParentKey())
                 ->whereNotNull($foreignKey);
         }
+
         return $desireResults;
     }
 }


### PR DESCRIPTION
This pull request introduces a crucial enhancement to Laravel's extended relationships, specifically targeting the `BelongsToArrayColumn` relation. The key addition here is the introduction of the `isString` option, offering users greater flexibility when dealing with array columns that may contain string representations of values.

The primary modification allows the BelongsToArrayColumn relation to smoothly handle string representations of array elements. Previously, the relation was designed to handle integer values exclusively. With the inclusion of the new`isString` option, users can now specify whether the array column contains string values, expanding the use cases for this relationship.

To illustrate the practical application of this enhancement, consider the scenario where an array column has values like` [7, 71]` – the relation seamlessly works without any adjustments. However, if the array column contains string representations, such as `["7", "71"]`, users can now set the` isString` flag to true when the current key is an integer, ensuring smooth integration.

This modification enables the `BelongsToArrayColumn` relation to cater to both integer and string representations, providing a more inclusive solution for various use cases. It's worth noting that in cases where both the current table and the array column contain string values, there's no need to specify the `isString` flag. The relation intuitively handles such scenarios, allowing for a seamless integration without additional configuration.

In conclusion, this enhancement aims to improve the usability of the `BelongsToArrayColumn` relation by accommodating string representations in array columns, offering users enhanced flexibility and a more inclusive experience.