### PR TITLE
Drop support for Laravel 11 and PHP 8.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,13 +16,10 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.5, 8.4, 8.3, 8.2]
-        laravel: ['11.*', '12.*', '13.*']
+        php: [8.5, 8.4, 8.3]
+        laravel: ['12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: ^9.10.0
-            carbon: ^2.72.6
           - laravel: 12.*
             testbench: ^10.3.0
             carbon: ^3.8.4
@@ -33,11 +30,6 @@ jobs:
           - laravel: 13.*
             testbench: ^11.0.0
             carbon: ^3.8.4
-        exclude:
-          - laravel: 11.*
-            php: 8.5
-          - laravel: 13.*
-            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `laravel-extended-relationships` will be documented in this file.
 
+## [Unreleased]
+
+### Breaking Changes
+- **BREAKING**: Dropped support for Laravel 11
+- **BREAKING**: Dropped support for PHP 8.2
+- Minimum requirements are now Laravel 12+ and PHP 8.3+
+
 ## [2.0.0]
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 ## Requirements
 
-- PHP: ^8.2|^8.3|^8.4|^8.5
-- Laravel: ^11.0|^12.0|^13.0
+- PHP: ^8.3|^8.4|^8.5
+- Laravel: ^12.0|^13.0
 
 ### What is a need of extended relationships?
 The laravel-extended-relationships package provides additional, more efficient relationship methods for Laravel Eloquent models. The package offers several useful features such as reducing the number of database queries, improving performance, and minimizing duplicate code.

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         }
     ],
     "require": {
-        "php": "^8.2|^8.3|^8.4|^8.5",
-        "illuminate/contracts": "^11.0|^12.0|^13.0"
+        "php": "^8.3|^8.4|^8.5",
+        "illuminate/contracts": "^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "mrpunyapal/rector-pest": "^0.1.0",
         "nunomaduro/collision": "^8.0",
-        "orchestra/testbench": "^9.10|^10.3|^11.0",
+        "orchestra/testbench": "^10.3|^11.0",
         "pestphp/pest": "^2.0|^3.0|^4.0",
         "pestphp/pest-plugin-arch": "^2.0|^3.0|^4.0",
         "pestphp/pest-plugin-laravel": "^2.2|^3.0|^4.0",


### PR DESCRIPTION
Raises the minimum supported versions for the upcoming major release.

## Breaking changes

- **Dropped Laravel 11** support — minimum is now Laravel 12 (`illuminate/contracts` `^12.0|^13.0`)
- **Dropped PHP 8.2** support — minimum is now PHP 8.3 (`php` `^8.3|^8.4|^8.5`)
- **Dropped `orchestra/testbench` `^9.x`** (the Laravel 11 era) from `require-dev`

## What changed

- CI test matrix (`run-tests.yml`) now tests Laravel 12 & 13 on PHP 8.3, 8.4, and 8.5; removed the Laravel 11 rows and related excludes
- `composer.json` requirements raised as above
- `README.md` requirements section updated
- `CHANGELOG.md` gained an Unreleased section documenting the breaking changes

The Laravel 11 rows were failing CI because Laravel 11 is end-of-life and every `laravel/framework` 11.x release is blocked by Packagist security advisories under Composer 2.8+. Dropping support resolves it cleanly.